### PR TITLE
Use array instead of object for plugins

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,11 +21,11 @@ module.exports = {
 
     .....
 
-    plugins: {
+    plugins: [{
       "hyperpower-plus": {
         "shake.enabled": false
       }
-    }
+    }]
   }
 }
 ```


### PR DESCRIPTION
`plugins` doesn't accept an object. Use an array instead.
